### PR TITLE
Update docs translation in Chinese

### DIFF
--- a/README-zh-cn.md
+++ b/README-zh-cn.md
@@ -1,13 +1,29 @@
 # ZeroNet-kivy
 [English](./README.md)
 
-ZeroNet的图形界面控制面板和APP打包，使用Kivy框架
-[Kivy](https://kivy.org) 是一个基于Python的跨平台的开源GUI框架。它可以部署到Android和iOS，甚至是桌面平台 (Win, Linux, Mac )。
+这个app是一个基础的控制ZeroNet客户端的图形界面。它使用buildozer和[Kivy](https://kivy.org) 框架打包生成。
 
-目前本项目的代码只能在Android上运行，欢迎对iOS开发感兴趣的同学加入。
+目前本项目的代码只能在Android上运行，欢迎对iOS开发感兴趣的同学加入。如果你想成为这个平台的维护者，请在[这里](https://github.com/HelloZeroNet/ZeroNet-kivy/issues/35)留言。
 目前本项目处于Alpha阶段，其GUI缺乏功能和美工设计，代码里保留了很多用于测试的代码。请贡献你的创意，无论是美工还是代码！
 
+# 下载
+
+你可以在这里下载app的最新版本：
+
+
+ - [ » PlayStore](https://play.google.com/store/apps/details?id=net.mkg20001.zeronet)
+ - [ » F-Droid repository for ZeroNet](https://f-droid.mkg20001.io/repos/jVVkbOD2it_bf_UxFIGGh1qa950KrUsq/repo/?fingerprint=005E888A5A203D40E28F372B939B8E5995FB29081EFC845DB99A8D4C14B509E2)
+ - [ » GitHub Releases](https://github.com/HelloZeroNet/ZeroNet-kivy/releases)
+
+## 想要为实在是太老版本的手机下载
+
+如果你使用Android 4或更低版本那你不能使用这个app。如果你非要的话，你可以从[ » 老版本](https://gateway.ipfs.io/ipfs/QmWKSoPfXpfvTU7jtiwn51zPVFZ6fWMiKNgDBzbnH9krXY/ZeroNet-OLDVERSION.apk)下载。但是注意：功能和安全性不保证。
+
+你也可以去列表 [ » 旧发行版们](https://github.com/mkg20001/ZeroNet-kivy/releases) 看看，如果你对早期的版本感兴趣的话。
+
 ### 屏幕截图:
+
+###　App
 
 #### 启动界面
 ![Startup](/screenshots/startup.png)
@@ -26,18 +42,18 @@ ZeroNet的图形界面控制面板和APP打包，使用Kivy框架
 
 ## 目标：
 
-* 易于安装
- - 去掉无用文件，减小安装包体积
- - 在Google Play, Apple App Store上发布，另外还有其他平台的官方APP市场或软件包仓库
-* 易于使用
- - 仅仅一触即可启动或停止ZeroNet服务
- - 稳定运行，防止被系统杀掉
-   + 在Android上，使ZeroNet运行为前台服务，降低被杀几率。如果还是被杀，可以创建一两个守护进程，用来重启ZeroNet服务。
- - 在移动设备上，降低电池、流量、存储的消耗量。自动调节ZeroNet在不同情景下的运行模式：是Wifi还是流量，是充着电还是低电量。当然，用户也能自行调节。
- - 使users.json和其他敏感数据保存在APP的内部私有目录，避免让其他APP接触到
- - 通过GUI导入主密钥或users.json，让用户能够跨设备使用同一ID
- - 通过GUI设置ZeroNet，而不是手动编辑zeronet.conf
- - 提供一个瘦客户端供用户选择。就像比特币瘦客户端一样，用户无需等待同步大量数据、消耗大量电量和存储，即可使用ZeroNet。瘦客户端向随机的代理 ( gateway ) 服务器接收和发送数据（发送前用私钥签名），私钥并不会泄露。
+* [ ] 易于安装
+ - [ ] 去掉无用文件，减小安装包体积
+ - [x] 在F-Droid, Google Play, Apple App Store上发布，另外还有其他平台的官方APP市场或软件包仓库
+* [ ] 易于使用
+ - [ ] 仅仅一触即可启动或停止ZeroNet服务
+ - [ ] 稳定运行，防止被系统杀掉
+   + [x] 在Android上，使ZeroNet运行为前台服务，降低被杀几率。如果还是被杀，可以创建一两个守护进程，用来重启ZeroNet服务。
+ - [ ] 在移动设备上，降低电池、流量、存储的消耗量。自动调节ZeroNet在不同情景下的运行模式：是Wifi还是流量，是充着电还是低电量。当然，用户也能自行调节。
+ - [ ] 使users.json和其他敏感数据保存在APP的内部私有目录，避免让其他APP接触到
+ - [ ] 通过GUI导入主密钥或users.json，让用户能够跨设备使用同一ID
+ - [ ] 通过GUI设置ZeroNet，而不是手动编辑zeronet.conf
+ - [ ] 提供一个瘦客户端供用户选择。就像比特币瘦客户端一样，用户无需等待同步大量数据、消耗大量电量和存储，即可使用ZeroNet。瘦客户端向随机的代理 ( gateway ) 服务器接收和发送数据（发送前用私钥签名），私钥并不会泄露。
 
 以上的目标，有一部分不是本项目单干就能搞定的，需要向ZeroNet贡献代码，提交更改。
 
@@ -46,18 +62,14 @@ ZeroNet的图形界面控制面板和APP打包，使用Kivy框架
 打包过程不是很难，因为Kivy的Buildozer自动化了很多工作。
 [打包教程在这，很详细的](./Tutorial-of-packaging-APK-zh-cn.md)
 
-## APK下载
-
-[ » 点击下载](https://github.com/HelloZeroNet/ZeroNet-kivy/releases)
-
-[ » 老版本](https://github.com/mkg20001/ZeroNet-kivy/releases)
 
 ## 如何使用APK
 
 * 注意你手机上的防火墙和权限控制的设置，请让本APK通过
 * 如果你浏览网站时遇到问题，请尝试其他浏览器
 * 如果你想关闭ZeroNet，请点击ZeroHello首页的左上角的⋮ 按钮，在菜单中选择关闭
-* 你可以升级ZeroNet本身的代码，方法跟在电脑上一样：点击ZeroHello首页的左上角的⋮ 按钮，在菜单中选择版本 x.x.x( rev xxxx)，不要管它是不是显示最新，就点它，就会升级到最新的开发版
+* 你可以升级ZeroNet本身的代码，方法跟在电脑上一样：点击ZeroHello首页的左上角的⋮ 按钮，在菜单中选择版本 x.x.x (rev xxxx)，不要管它是不是显示最新，就点它，就会升级到最新的开发版
+× 你可以在/Android/data/net.mkg20001.zeronet/files/zero里找到所有ZeroNet的东西，干你想干事情
 * 遇到bug或其他问题到外部存储/Android/data/包名如android.test.myapp17/files/zero/log里的log看看有什么异常报错
 
 ## 项目结构一览
@@ -68,4 +80,4 @@ ZeroNet的图形界面控制面板和APP打包，使用Kivy框架
     - platform_*.py - 平台具体代码
     * zero -  ZeroNet本身的全部代码 (if content is missing run `git submodule init --recursive`)
       - zeronet.py - ZeroNet 启动器
-  * buildozer.spec - Buildozer的配置，你可以定义APK的包名、标题、版本号、android权限、服务等等.
+  * buildozer.spec - Buildozer的配置，你可以定义APK的包名、标题、版本号、android权限、服务等等。

--- a/Tutorial-of-packaging-APK-zh-cn.md
+++ b/Tutorial-of-packaging-APK-zh-cn.md
@@ -7,7 +7,7 @@
  - Git
  - Make
  - ADB
- - Docker or Vagrant (vagrant的话请看文章最后）
+ - Docker or Vagrant
 
 ## 初始步骤
  - 首先 `git clone https://github.com/HelloZeroNet/ZeroNet-kivy --recursive`

--- a/Tutorial-of-packaging-APK-zh-cn.md
+++ b/Tutorial-of-packaging-APK-zh-cn.md
@@ -1,40 +1,52 @@
 # 指导:
 
-在Ubuntu 16.04上测试过
+在Ubuntu 18.04上测试过
 
 必需品：
- - A phone or armv7 emulator (can't build for non-arm currently)
+ - 一个手机或者armv7模拟器（目前不能在非arm架构上build）
  - Git
  - Make
  - ADB
- - Docker or Vagrant (for vagrant please skip to the bottom)
+ - Docker or Vagrant (vagrant的话请看文章最后）
 
 ## 初始步骤
  - 首先 `git clone https://github.com/HelloZeroNet/ZeroNet-kivy --recursive`
  - 现在验证在 `src/zero` 的内容
+ - （如果你clone的时候没有用`--recursive`，那么运行`git submodule init && git submodule update`）
 
-## 安装
- - 首先，您需要生成环境配置。使用`make .env`执行此操作
- - 之后使用`make .pre`准备构建
+## 搭建（Setup）
 
-## 建设
+### Ｄocker (推荐)
+ - 运行`make .env`。这一步会有一些问题弹出（通常你可以保持默认选项）然后再拉取docker的镜像。
+ - 现在运行`setup`完成搭建
+
+### Ｖagrant
+ - 运行 `vagrant up`。这一步会创建一个ubuntu 18.04的vm并且为你执行一些必要的搭建指令
+ - 注意：
+   - 在vagrant VM**之内**运行所有 _building_ 指令 (使用 `vagrant ssh` 进入vm)
+   - 在vagrant VM**之外**运行所有把app安装到你的手机上的指令
+   - 你需要安装adb来测试. 在VM**之外**运行 `make run` 或者 `make test` 
+	  - 如果你安装了它，运行 `make run`
+	  - 如果您使用模拟器，请在命令后附加 `ADB_FLAG=-e`
+
+
+### 本地机器
+ - 运行`make .env`
+	
+## 生成（Building）
  - 运行`make debug`来构建应用程序的调试版本
  - 运行`make release`来构建应用程序的发布版本
- - 如果构建成功，则会显示带有ZeroNet.apk的bin文件夹
+ - 如果构建成功，一个含有ZeroNet.apk的bin文件夹会出现
  - 运行`make run`来测试连接手机上的应用程序
    - 果您使用模拟器，请在命令后附加`ADB_FLAG=-e`
 
 ## 调试  
- - 运行 `make test` 应该启动adb logcat
+ - 运行 `make test` 会启动adb logcat
  - 其他日志位于 `/storage/emulated/0/Android/data/net.mkg20001.zeronet/files/zero/log`
  - 如果`make test`不起作用，请尝试`make run`
 
-## Vagrant
- - 首先运行 `vagrant up`
- - 这应该创建和准备虚拟机
-
 ### Building
 - 运行所有命令 **inside** the vagrant VM (Use `vagrant ssh` to enter the vm)
-- 测试你需要安装adb. Run `make run` or `make test` **outside** the VM
+- 你需要安装adb来测试. 运行 `make run` 或者 `make test` **outside** the VM
   - 如果你安装了它，运行 `make run`
   - 如果您使用模拟器，请在命令后附加 `ADB_FLAG=-e`


### PR DESCRIPTION
For the issue https://github.com/HelloZeroNet/ZeroNet-kivy/issues/55

Besides, in the https://github.com/HelloZeroNet/ZeroNet-kivy/blob/master/Tutorial-of-packaging-APK.md, the last ``### building`` part is duplicated with the ``### Vagrant`` part? If you think the last part should be removed, also remove the last part in Chinese version.(Or I can remove it, too)